### PR TITLE
Fix MOA with local solvers not supporting delete

### DIFF
--- a/src/algorithms/Dichotomy.jl
+++ b/src/algorithms/Dichotomy.jl
@@ -64,7 +64,6 @@ function _solve_weighted_sum(
     MOI.set(model.inner, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.optimize!(model.inner)
     status = MOI.get(model.inner, MOI.TerminationStatus())
-    status = MOI.get(model.inner, MOI.TerminationStatus())
     if !_is_scalar_status_optimal(status)
         return status, nothing
     end

--- a/src/algorithms/DominguezRios.jl
+++ b/src/algorithms/DominguezRios.jl
@@ -201,7 +201,7 @@ function optimize_multiobjective!(algorithm::DominguezRios, model::Optimizer)
         new_f = t_max + ϵ * sum(w[i] * (scalars[i] - yI[i]) for i in 1:n)
         MOI.set(model.inner, MOI.ObjectiveFunction{typeof(new_f)}(), new_f)
         MOI.optimize!(model.inner)
-        if MOI.get(model.inner, MOI.TerminationStatus()) == MOI.OPTIMAL
+        if _is_scalar_status_optimal(model)
             X, Y = _compute_point(model, variables, model.f)
             obj = MOI.get(model.inner, MOI.ObjectiveValue())
             if (obj < 1) && all(yI .< B.u)

--- a/src/algorithms/EpsilonConstraint.jl
+++ b/src/algorithms/EpsilonConstraint.jl
@@ -107,7 +107,7 @@ function optimize_multiobjective!(
     while true
         MOI.set(model, MOI.ConstraintSet(), ci, SetType(bound))
         MOI.optimize!(model.inner)
-        if MOI.get(model.inner, MOI.TerminationStatus()) != MOI.OPTIMAL
+        if !_is_scalar_status_optimal(model)
             break
         end
         X, Y = _compute_point(model, variables, model.f)

--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -153,7 +153,7 @@ function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
             end
         end
         MOI.optimize!(model.inner)
-        if MOI.get(model.inner, MOI.TerminationStatus()) != MOI.OPTIMAL
+        if !_is_scalar_status_optimal(model)
             _remove_rectangle(L, _Rectangle(_project(yI, k), uᵢ))
             MOI.delete.(model, ε_constraints)
             continue
@@ -169,7 +169,7 @@ function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
         MOI.optimize!(model.inner)
         MOI.delete.(model, ε_constraints)
         MOI.delete(model, zₖ_constraint)
-        if MOI.get(model.inner, MOI.TerminationStatus()) != MOI.OPTIMAL
+        if !_is_scalar_status_optimal(model)
             _remove_rectangle(L, _Rectangle(_project(yI, k), uᵢ))
             continue
         end

--- a/test/algorithms/EpsilonConstraint.jl
+++ b/test/algorithms/EpsilonConstraint.jl
@@ -289,6 +289,34 @@ function test_deprecated()
     return
 end
 
+function test_quadratic()
+    μ = [0.05470748600000001, 0.18257110599999998]
+    Q = [0.00076204 0.00051972; 0.00051972 0.00546173]
+    N = 2
+    model = MOA.Optimizer(Ipopt.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.EpsilonConstraint())
+    MOI.set(model, MOA.SolutionLimit(), 10)
+    MOI.set(model, MOI.Silent(), true)
+    w = MOI.add_variables(model, N)
+    MOI.add_constraint.(model, w, MOI.GreaterThan(0.0))
+    MOI.add_constraint.(model, w, MOI.LessThan(1.0))
+    MOI.add_constraint(model, sum(1.0 * w[i] for i in 1:N), MOI.EqualTo(1.0))
+    var = sum(Q[i, j] * w[i] * w[j] for i in 1:N, j in 1:N)
+    mean = sum(-μ[i] * w[i] for i in 1:N)
+    f = MOI.Utilities.operate(vcat, Float64, var, mean)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.ResultCount()) == 10
+    for i in 1:MOI.get(model, MOI.ResultCount())
+        w_sol = MOI.get(model, MOI.VariablePrimal(i), w)
+        y = MOI.get(model, MOI.ObjectiveValue(i))
+        @test y ≈ [w_sol' * Q * w_sol, -μ' * w_sol]
+    end
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    return
+end
+
 end
 
 TestEpsilonConstraint.run_tests()

--- a/test/algorithms/EpsilonConstraint.jl
+++ b/test/algorithms/EpsilonConstraint.jl
@@ -8,6 +8,7 @@ module TestEpsilonConstraint
 using Test
 
 import HiGHS
+import Ipopt
 import MultiObjectiveAlgorithms as MOA
 
 const MOI = MOA.MOI

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -36,6 +36,7 @@ function test_moi_runtests()
         exclude = String[
             # Skipped beause of UniversalFallback in _mock_optimizer
             "test_attribute_Silent",
+            "test_attribute_after_empty",
             "test_model_copy_to_UnsupportedAttribute",
             "test_model_copy_to_UnsupportedConstraint",
             "test_model_supports_constraint_ScalarAffineFunction_EqualTo",


### PR DESCRIPTION
Closes #44

This also fixes a bunch of cases which assume `MOI.OPTIMAL` is the only status that may be returned.