### PR TITLE
Remove unused S parameter

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -350,7 +350,7 @@ function MOI.set(
     attr::MOI.AbstractVariableAttribute,
     indices::Vector{<:MOI.VariableIndex},
     args::Vector{T},
-) where {S,T}
+) where {T}
     MOI.set.(model, attr, indices, args)
     return
 end
@@ -374,7 +374,7 @@ function MOI.set(
     attr::MOI.AbstractConstraintAttribute,
     indices::Vector{<:MOI.ConstraintIndex},
     args::Vector{T},
-) where {S,T}
+) where {T}
     MOI.set.(model, attr, indices, args)
     return
 end


### PR DESCRIPTION
This gives warning when using the package
```julia
WARNING: method definition for set at /home/blegat/.julia/packages/MultiObjectiveAlgorithms/80Aze/src/MultiObjectiveAlgorithms.jl:348 declares type variable S but does not use it.
WARNING: method definition for set at /home/blegat/.julia/packages/MultiObjectiveAlgorithms/80Aze/src/MultiObjectiveAlgorithms.jl:372 declares type variable S but does not use it.
```
so it's worth doing a patch release with this fix