### PR TITLE
Support solve_time(model)

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -109,7 +109,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     solutions::Vector{SolutionPoint}
     termination_status::MOI.TerminationStatusCode
     time_limit_sec::Union{Nothing,Float64}
-    solve_time::Union{Nothing,Float64}
+    solve_time::Float64
 
     function Optimizer(optimizer_factory)
         return new(
@@ -119,7 +119,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             SolutionPoint[],
             MOI.OPTIMIZE_NOT_CALLED,
             nothing,
-            nothing,
+            NaN,
         )
     end
 end
@@ -129,7 +129,7 @@ function MOI.empty!(model::Optimizer)
     model.f = nothing
     model.solutions = SolutionPoint[]
     model.termination_status = MOI.OPTIMIZE_NOT_CALLED
-    model.solve_time = nothing
+    model.solve_time = NaN
     return
 end
 
@@ -138,7 +138,7 @@ function MOI.is_empty(model::Optimizer)
            model.f === nothing &&
            isempty(model.solutions) &&
            model.termination_status == MOI.OPTIMIZE_NOT_CALLED &&
-           model.solve_time === nothing
+           isnan(model.solve_time)
 end
 
 MOI.supports_incremental_interface(::Optimizer) = true
@@ -182,7 +182,7 @@ end
 
 ### SolveTimeSec
 
-function MOI.get(model::Optimizer, attr::MOI.SolveTimeSec)
+function MOI.get(model::Optimizer, ::MOI.SolveTimeSec)
     return model.solve_time
 end
 

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -88,6 +88,20 @@ function test_time_limit()
     return
 end
 
+function test_solve_time()
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(model, MOI.SolveTimeSec()) === nothing
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.SolveTimeSec()) >= 0
+    return
+end
+
 end
 
 TestModel.run_tests()

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -96,7 +96,7 @@ function test_solve_time()
     f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-    @test MOI.get(model, MOI.SolveTimeSec()) === nothing
+    @test isnan(MOI.get(model, MOI.SolveTimeSec()))
     MOI.optimize!(model)
     @test MOI.get(model, MOI.SolveTimeSec()) >= 0
     return


### PR DESCRIPTION
Currently, `solve_time` call is passed to the solver and the returned time corresponds to the last optimization only.

- [x] Need to add some tests