### PR TITLE
Add Tamby Vanderpooten algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The value must be one of the algorithms supported by MOA:
  * `MOA.Hierarchical()`
  * `MOA.KirlikSayin()`
  * `MOA.Lexicographic()` [default]
+ * `MOA.TambyVanderpooten()`
 
 Consult their docstrings for details.
 

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -44,7 +44,7 @@ function _update_search_region(
             for l in 1:p
                 u_l = _get_child(u, y, l)
                 N = [
-                    k ≠ l ? [yᵢ for yᵢ in U_N[u][k] if yᵢ[l] < y[l]] : [y]
+                    k != l ? [yi for yi in U_N[u][k] if yi[l] < y[l]] : [y]
                     for k in 1:p
                 ]
                 if all(!isempty(N[k]) for k in 1:p if u_l[k] ≠ yN[k])
@@ -102,12 +102,6 @@ function optimize_multiobjective!(
     warm_start_supported = false
     if MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
         warm_start_supported = true
-    else
-        solver_name = MOI.get(model.inner, MOI.SolverName())
-        @warn """
-        Solver $solver_name does not support MOI.VariablePrimalStart(). 
-        It may take longer to generate the pareto set.
-        """
     end
     solutions = Dict{Vector{Float64},Dict{MOI.VariableIndex,Float64}}()
     YN = Vector{Float64}[]
@@ -194,7 +188,6 @@ function optimize_multiobjective!(
         push!(V[k], (u, Y))
         if Y ∉ U_N[u][k]
             _update_search_region(U_N, Y, yN)
-            # push!(solutions, SolutionPoint(X, Y))
             solutions[Y] = X
         end
         bounds_to_remove = Vector{Float64}[]

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -1,0 +1,223 @@
+#  Copyright 2019, Oscar Dowson and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public License,
+#  v.2.0. If a copy of the MPL was not distributed with this file, You can
+#  obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+    TambyVanderpooten()
+
+`TambyVanderpooten` implements the algorithm of:
+
+Satya Tamby, Daniel Vanderpooten (2021) Enumeration of the Nondominated Set 
+of Multiobjective Discrete Optimization Problems. INFORMS Journal on 
+Computing 33(1):72-85.
+
+This is an algorithm to generate all nondominated solutions for multi-objective
+discrete optimization problems. The algorithm maintains upper bounds (for 
+minimization problems) and their associated defining points. At each iteration, 
+one of the objectives and an upper bound is picked and the single objective 
+reformulation is solved using one of the defining points as a starting solution.
+
+## Supported optimizer attributes
+
+ * `MOI.TimeLimitSec()`: terminate if the time limit is exceeded and return the
+    list of current solutions.
+"""
+mutable struct TambyVanderpooten <: AbstractAlgorithm end
+
+function _project(x::Vector{Float64}, axis::Int)
+    return [x[i] for i in 1:length(x) if i != axis]
+end
+
+_volume(r::_Rectangle, l::Vector{Float64}) = prod(r.u - l)
+
+function _update_search_region(
+    U_N::Dict{Vector{Float64},Vector{Vector{Vector{Float64}}}},
+    y::Vector{Float64},
+    yN::Vector{Float64},
+)
+    bounds_to_remove = Vector{Float64}[]
+    p = length(y)
+    for u in keys(U_N)
+        if all(y .< u)
+            push!(bounds_to_remove, u)
+            for l in 1:p
+                u_l = _get_child(u, y, l)
+                N = [
+                    k ≠ l ? [yᵢ for yᵢ in U_N[u][k] if yᵢ[l] < y[l]] : [y]
+                    for k in 1:p
+                ]
+                if all(!isempty(N[k]) for k in 1:p if u_l[k] ≠ yN[k])
+                    U_N[u_l] = N
+                end
+            end
+        else
+            for k in 1:p
+                if (y[k] == u[k]) && all(_project(y, k) .< _project(u, k))
+                    push!(U_N[u][k], y)
+                end
+            end
+        end
+    end
+    for bound_to_remove in bounds_to_remove
+        delete!(U_N, bound_to_remove)
+    end
+end
+
+function _get_child(u::Vector{Float64}, y::Vector{Float64}, k::Int)
+    @assert length(u) == length(y)
+    return vcat(u[1:k-1], y[k], u[k+1:length(y)])
+end
+
+function _select_search_zone(
+    U_N::Dict{Vector{Float64},Vector{Vector{Vector{Float64}}}},
+    yI::Vector{Float64},
+)
+    i, j =
+        argmax([
+            prod(_project(u, k) - _project(yI, k)) for k in 1:length(yI),
+            u in keys(U_N)
+        ]).I
+    return i, collect(keys(U_N))[j]
+end
+
+function optimize_multiobjective!(
+    algorithm::TambyVanderpooten,
+    model::Optimizer,
+)
+    start_time = time()
+    sense = MOI.get(model.inner, MOI.ObjectiveSense())
+    if sense == MOI.MAX_SENSE
+        old_obj, neg_obj = copy(model.f), -model.f
+        MOI.set(model, MOI.ObjectiveFunction{typeof(neg_obj)}(), neg_obj)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+        status, solutions = optimize_multiobjective!(algorithm, model)
+        MOI.set(model, MOI.ObjectiveFunction{typeof(old_obj)}(), old_obj)
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+        if solutions !== nothing
+            solutions = [SolutionPoint(s.x, -s.y) for s in solutions]
+        end
+        return status, solutions
+    end
+    warm_start_supported = false
+    if MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+        warm_start_supported = true
+    else
+        solver_name = MOI.get(model.inner, MOI.SolverName())
+        @warn """
+        Solver $solver_name does not support MOI.VariablePrimalStart(). 
+        It may take longer to generate the pareto set.
+        """
+    end
+    solutions = Dict{Vector{Float64},Dict{MOI.VariableIndex,Float64}}()
+    YN = Vector{Float64}[]
+    variables = MOI.get(model.inner, MOI.ListOfVariableIndices())
+    n = MOI.output_dimension(model.f)
+    yI, yN = zeros(n), zeros(n)
+    scalars = MOI.Utilities.scalarize(model.f)
+    for (i, f_i) in enumerate(scalars)
+        MOI.set(model.inner, MOI.ObjectiveFunction{typeof(f_i)}(), f_i)
+        MOI.set(model.inner, MOI.ObjectiveSense(), sense)
+        MOI.optimize!(model.inner)
+        status = MOI.get(model.inner, MOI.TerminationStatus())
+        if !_is_scalar_status_optimal(status)
+            return status, nothing
+        end
+        _, Y = _compute_point(model, variables, f_i)
+        yI[i] = Y
+        MOI.set(model.inner, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+        MOI.optimize!(model.inner)
+        status = MOI.get(model.inner, MOI.TerminationStatus())
+        if !_is_scalar_status_optimal(status)
+            _warn_on_nonfinite_anti_ideal(algorithm, sense, i)
+            return status, nothing
+        end
+        _, Y = _compute_point(model, variables, f_i)
+        yN[i] = Y
+    end
+    MOI.set(model.inner, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    U_N = Dict{Vector{Float64},Vector{Vector{Vector{Float64}}}}()
+    V = [Tuple{Vector{Float64},Vector{Float64}}[] for k in 1:n]
+    U_N[yN] = [[_get_child(yN, yI, k)] for k in 1:n]
+    status = MOI.OPTIMAL
+    while !isempty(U_N)
+        if _time_limit_exceeded(model, start_time)
+            status = MOI.TIME_LIMIT
+            break
+        end
+        k, u = _select_search_zone(U_N, yI)
+        MOI.set(
+            model.inner,
+            MOI.ObjectiveFunction{typeof(scalars[k])}(),
+            scalars[k],
+        )
+        ε_constraints = Any[]
+        for (i, f_i) in enumerate(scalars)
+            if i != k
+                ci = MOI.add_constraint(
+                    model.inner,
+                    f_i,
+                    MOI.LessThan{Float64}(u[i] - 1),
+                )
+                push!(ε_constraints, ci)
+            end
+        end
+        if u[k] ≠ yN[k]
+            if warm_start_supported
+                variables_start = solutions[rand(U_N[u][k])]
+                for x_i in variables
+                    MOI.set(
+                        model.inner,
+                        MOI.VariablePrimalStart(),
+                        x_i,
+                        variables_start[x_i],
+                    )
+                end
+            end
+        end
+        MOI.optimize!(model.inner)
+        if !_is_scalar_status_optimal(model)
+            return status, nothing
+        end
+        y_k = MOI.get(model.inner, MOI.ObjectiveValue())
+        sum_f = sum(1.0 * s for s in scalars)
+        MOI.set(model.inner, MOI.ObjectiveFunction{typeof(sum_f)}(), sum_f)
+        y_k_constraint =
+            MOI.add_constraint(model.inner, scalars[k], MOI.EqualTo(y_k))
+        MOI.optimize!(model.inner)
+        if !_is_scalar_status_optimal(model)
+            return status, nothing
+        end
+        X, Y = _compute_point(model, variables, model.f)
+        MOI.delete.(model, ε_constraints)
+        MOI.delete(model, y_k_constraint)
+        push!(V[k], (u, Y))
+        if Y ∉ U_N[u][k]
+            _update_search_region(U_N, Y, yN)
+            # push!(solutions, SolutionPoint(X, Y))
+            solutions[Y] = X
+        end
+        bounds_to_remove = Vector{Float64}[]
+        for u_i in keys(U_N)
+            for k in 1:n
+                if u_i[k] == yI[k]
+                    push!(bounds_to_remove, u_i)
+                else
+                    for (u_j, y_j) in V[k]
+                        if all(_project(u_i, k) .<= _project(u_j, k)) &&
+                           (y_j[k] == u_i[k])
+                            push!(bounds_to_remove, u_i)
+                        end
+                    end
+                end
+            end
+        end
+        if !isempty(bounds_to_remove)
+            for bound_to_remove in bounds_to_remove
+                delete!(U_N, bound_to_remove)
+            end
+        end
+    end
+    solutions = [SolutionPoint(X, Y) for (Y, X) in solutions]
+    return status, solutions
+end

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -62,6 +62,7 @@ function _update_search_region(
     for bound_to_remove in bounds_to_remove
         delete!(U_N, bound_to_remove)
     end
+    return
 end
 
 function _get_child(u::Vector{Float64}, y::Vector{Float64}, k::Int)
@@ -212,5 +213,6 @@ function optimize_multiobjective!(
         end
     end
     solutions = [SolutionPoint(X, Y) for (Y, X) in solutions]
+    sort!(solutions, by = s -> s.y)
     return status, solutions
 end

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -213,6 +213,5 @@ function optimize_multiobjective!(
         end
     end
     solutions = [SolutionPoint(X, Y) for (Y, X) in solutions]
-    sort!(solutions, by = s -> s.y)
     return status, solutions
 end

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -164,7 +164,7 @@ function optimize_multiobjective!(
         end
         if u[k] ≠ yN[k]
             if warm_start_supported
-                variables_start = solutions[rand(U_N[u][k])]
+                variables_start = solutions[first(U_N[u][k])]
                 for x_i in variables
                     MOI.set(
                         model.inner,

--- a/test/algorithms/TambyVanderpooten.jl
+++ b/test/algorithms/TambyVanderpooten.jl
@@ -274,9 +274,6 @@ function test_knapsack_max_p4()
 end
 
 function test_assignment_min_p3()
-    if Sys.WORD_SIZE == 32
-        return  # Skip on 32-bit because HiGHS fails
-    end
     p = 3
     n = 5
     C = Float64[
@@ -387,9 +384,6 @@ function test_assignment_min_p3()
 end
 
 function test_assignment_max_p3()
-    if Sys.WORD_SIZE == 32
-        return  # Skip on 32-bit because HiGHS fails
-    end
     p = 3
     n = 5
     C = Float64[

--- a/test/algorithms/TambyVanderpooten.jl
+++ b/test/algorithms/TambyVanderpooten.jl
@@ -58,27 +58,31 @@ function test_knapsack_min_p3()
     MOI.optimize!(model)
     X_E = Float64[
         1 0 1 1 1 0 1 1 0 1
-        0 0 1 1 1 0 1 1 1 1
+        0 1 1 1 1 0 1 0 1 1
         1 1 1 1 1 0 0 0 0 1
-        1 0 1 1 1 0 0 1 1 0
         0 1 1 1 1 0 0 1 0 1
         1 1 1 1 1 0 0 0 1 0
-        0 1 1 1 1 0 1 0 1 1
+        1 0 1 1 1 0 0 1 1 0
+        0 0 1 1 1 0 1 1 1 1
     ]
     Y_N = Float64[
         -3394 -3817 -3408
-        -2854 -4636 -3076
+        -3042 -4627 -3189
         -2997 -3539 -3509
-        -2518 -3866 -3191
         -2854 -3570 -3714
         -2706 -3857 -3304
-        -3042 -4627 -3189
+        -2518 -3866 -3191
+        -2854 -4636 -3076
     ]
     N = MOI.get(model, MOI.ResultCount())
-    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 
@@ -117,27 +121,31 @@ function test_knapsack_max_p3()
     MOI.optimize!(model)
     X_E = Float64[
         1 0 1 1 1 0 1 1 0 1
-        0 0 1 1 1 0 1 1 1 1
+        0 1 1 1 1 0 1 0 1 1
         1 1 1 1 1 0 0 0 0 1
-        1 0 1 1 1 0 0 1 1 0
         0 1 1 1 1 0 0 1 0 1
         1 1 1 1 1 0 0 0 1 0
-        0 1 1 1 1 0 1 0 1 1
+        1 0 1 1 1 0 0 1 1 0
+        0 0 1 1 1 0 1 1 1 1
     ]
     Y_N = Float64[
         3394 3817 3408
-        2854 4636 3076
+        3042 4627 3189
         2997 3539 3509
-        2518 3866 3191
         2854 3570 3714
         2706 3857 3304
-        3042 4627 3189
+        2518 3866 3191
+        2854 4636 3076
     ]
     N = MOI.get(model, MOI.ResultCount())
-    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 
@@ -176,34 +184,38 @@ function test_knapsack_min_p4()
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.optimize!(model)
     X_E = Float64[
-        0 1 1 0 1 0 1 0 1 1
-        0 1 1 0 1 1 1 1 1 0
-        0 0 1 0 1 1 1 0 1 1
-        0 1 1 1 1 0 1 0 1 0
         1 1 1 0 1 1 1 0 0 0
-        0 1 0 0 0 1 1 1 1 1
+        0 1 1 0 1 1 1 1 1 0
+        0 1 1 1 1 1 1 0 0 0
+        0 1 1 0 1 0 1 0 1 1
+        0 1 1 1 1 0 1 0 1 0
+        0 0 1 0 1 1 1 0 1 1
         0 1 1 1 0 1 1 0 1 0
         0 0 1 1 0 1 1 1 1 0
         0 0 1 1 1 1 1 0 1 0
-        0 1 1 1 1 1 1 0 0 0
+        0 1 0 0 0 1 1 1 1 1
     ]
     Y_N = Float64[
-        -2862 -3648 -3049 -2028
-        -3152 -3232 -3596 -3382
-        -2435 -3618 -2282 -2094
-        -2725 -4064 -2652 -1819
         -3269 -2320 -3059 -2891
-        -2146 -1944 -2947 -3428
+        -3152 -3232 -3596 -3382
+        -2883 -3237 -2535 -2397
+        -2862 -3648 -3049 -2028
+        -2725 -4064 -2652 -1819
+        -2435 -3618 -2282 -2094
         -2092 -3244 -2643 -2705
         -1904 -3253 -2530 -2469
         -2298 -4034 -1885 -1885
-        -2883 -3237 -2535 -2397
+        -2146 -1944 -2947 -3428
     ]
     N = MOI.get(model, MOI.ResultCount())
-    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 
@@ -242,34 +254,38 @@ function test_knapsack_max_p4()
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.optimize!(model)
     X_E = Float64[
-        0 1 1 0 1 0 1 0 1 1
-        0 1 1 0 1 1 1 1 1 0
-        0 0 1 0 1 1 1 0 1 1
-        0 1 1 1 1 0 1 0 1 0
         1 1 1 0 1 1 1 0 0 0
-        0 1 0 0 0 1 1 1 1 1
+        0 1 1 0 1 1 1 1 1 0
+        0 1 1 1 1 1 1 0 0 0
+        0 1 1 0 1 0 1 0 1 1
+        0 1 1 1 1 0 1 0 1 0
+        0 0 1 0 1 1 1 0 1 1
         0 1 1 1 0 1 1 0 1 0
         0 0 1 1 0 1 1 1 1 0
         0 0 1 1 1 1 1 0 1 0
-        0 1 1 1 1 1 1 0 0 0
+        0 1 0 0 0 1 1 1 1 1
     ]
     Y_N = Float64[
-        2862 3648 3049 2028
-        3152 3232 3596 3382
-        2435 3618 2282 2094
-        2725 4064 2652 1819
         3269 2320 3059 2891
-        2146 1944 2947 3428
+        3152 3232 3596 3382
+        2883 3237 2535 2397
+        2862 3648 3049 2028
+        2725 4064 2652 1819
+        2435 3618 2282 2094
         2092 3244 2643 2705
         1904 3253 2530 2469
         2298 4034 1885 1885
-        2883 3237 2535 2397
+        2146 1944 2947 3428
     ]
     N = MOI.get(model, MOI.ResultCount())
-    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 
@@ -329,57 +345,61 @@ function test_assignment_min_p3()
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.optimize!(model)
     X_E = Float64[
-        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
-        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
-        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
-        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
-        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
         0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1
+        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
+        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
+        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
         0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 1 0
         0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1
-        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
-        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
-        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
-        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
-        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
-        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
         0 0 0 0 1 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0
+        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
     ]
     Y_N = Float64[
-        28 33 58
-        40 47 37
-        39 43 41
-        45 33 34
-        29 29 59
-        20 52 54
-        28 66 39
-        50 40 32
         16 61 47
+        17 43 71
+        18 47 67
+        20 52 54
+        22 37 63
+        23 43 44
+        22 54 47
+        28 66 39
+        34 60 42
+        24 39 45
         35 49 39
         37 55 36
-        24 39 45
-        18 47 67
-        22 54 47
-        38 33 53
-        34 60 42
-        23 43 44
-        17 43 71
-        22 37 63
-        43 51 31
+        28 33 58
         35 38 56
+        39 43 41
+        38 33 53
+        45 33 34
+        43 51 31
+        40 47 37
+        29 29 59
+        50 40 32
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
-        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 
@@ -439,57 +459,61 @@ function test_assignment_max_p3()
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.optimize!(model)
     X_E = Float64[
-        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
-        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
-        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
-        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
-        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
         0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1
+        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
+        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
+        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
         0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 1 0
         0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1
-        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
-        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
-        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
-        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
-        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
-        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
-        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
-        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
         0 0 0 0 1 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0
+        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
     ]
     Y_N = Float64[
-        -28 -33 -58
-        -40 -47 -37
-        -39 -43 -41
-        -45 -33 -34
-        -29 -29 -59
-        -20 -52 -54
-        -28 -66 -39
-        -50 -40 -32
         -16 -61 -47
+        -17 -43 -71
+        -18 -47 -67
+        -20 -52 -54
+        -22 -37 -63
+        -23 -43 -44
+        -22 -54 -47
+        -28 -66 -39
+        -34 -60 -42
+        -24 -39 -45
         -35 -49 -39
         -37 -55 -36
-        -24 -39 -45
-        -18 -47 -67
-        -22 -54 -47
-        -38 -33 -53
-        -34 -60 -42
-        -23 -43 -44
-        -17 -43 -71
-        -22 -37 -63
-        -43 -51 -31
+        -28 -33 -58
         -35 -38 -56
+        -39 -43 -41
+        -38 -33 -53
+        -45 -33 -34
+        -43 -51 -31
+        -40 -47 -37
+        -29 -29 -59
+        -50 -40 -32
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
-        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)'
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)'
+    y_sol, x_sol = y_sol[sortperm(collect(eachrow(y_sol))), :],
+    x_sol[sortperm(collect(eachrow(y_sol))), :]
+    Y_N, X_E = Y_N[sortperm(collect(eachrow(Y_N))), :],
+    X_E[sortperm(collect(eachrow(Y_N))), :]
+    @test isapprox(x_sol, X_E; atol = 1e-6)
+    @test isapprox(y_sol, Y_N; atol = 1e-6)
     return
 end
 

--- a/test/algorithms/TambyVanderpooten.jl
+++ b/test/algorithms/TambyVanderpooten.jl
@@ -1,0 +1,608 @@
+#  Copyright 2019, Oscar Dowson and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public License,
+#  v.2.0. If a copy of the MPL was not distributed with this file, You can
+#  obtain one at http://mozilla.org/MPL/2.0/.
+
+module TestTambyVanderpooten
+
+using Test
+
+import HiGHS
+import MultiObjectiveAlgorithms as MOA
+
+const MOI = MOA.MOI
+
+function run_tests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$name", "test_")
+            @testset "$name" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_knapsack_min_p3()
+    p = 3
+    n = 10
+    W = 2137.0
+    C = Float64[
+        566 611 506 180 817 184 585 423 26 317
+        62 84 977 979 874 54 269 93 881 563
+        664 982 962 140 224 215 12 869 332 537
+    ]
+    w = Float64[557, 898, 148, 63, 78, 964, 246, 662, 386, 272]
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(w[j], x[j]) for j in 1:n],
+            0.0,
+        ),
+        MOI.LessThan(W),
+    )
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(-C[i, j], x[j]))
+            for i in 1:p for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        1 0 1 1 1 0 1 1 0 1
+        0 0 1 1 1 0 1 1 1 1
+        1 1 1 1 1 0 0 0 0 1
+        1 0 1 1 1 0 0 1 1 0
+        0 1 1 1 1 0 0 1 0 1
+        1 1 1 1 1 0 0 0 1 0
+        0 1 1 1 1 0 1 0 1 1
+    ]
+    Y_N = Float64[
+        -3394 -3817 -3408
+        -2854 -4636 -3076
+        -2997 -3539 -3509
+        -2518 -3866 -3191
+        -2854 -3570 -3714
+        -2706 -3857 -3304
+        -3042 -4627 -3189
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_knapsack_max_p3()
+    p = 3
+    n = 10
+    W = 2137.0
+    C = Float64[
+        566 611 506 180 817 184 585 423 26 317
+        62 84 977 979 874 54 269 93 881 563
+        664 982 962 140 224 215 12 869 332 537
+    ]
+    w = Float64[557, 898, 148, 63, 78, 964, 246, 662, 386, 272]
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(w[j], x[j]) for j in 1:n],
+            0.0,
+        ),
+        MOI.LessThan(W),
+    )
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(C[i, j], x[j])) for
+            i in 1:p for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        1 0 1 1 1 0 1 1 0 1
+        0 0 1 1 1 0 1 1 1 1
+        1 1 1 1 1 0 0 0 0 1
+        1 0 1 1 1 0 0 1 1 0
+        0 1 1 1 1 0 0 1 0 1
+        1 1 1 1 1 0 0 0 1 0
+        0 1 1 1 1 0 1 0 1 1
+    ]
+    Y_N = Float64[
+        3394 3817 3408
+        2854 4636 3076
+        2997 3539 3509
+        2518 3866 3191
+        2854 3570 3714
+        2706 3857 3304
+        3042 4627 3189
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_knapsack_min_p4()
+    p = 4
+    n = 10
+    W = 2653.0
+    C = Float64[
+        566 611 506 180 817 184 585 423 26 317
+        62 84 977 979 874 54 269 93 881 563
+        664 982 962 140 224 215 12 869 332 537
+        557 898 148 63 78 964 246 662 386 272
+    ]
+    w = Float64[979 448 355 955 426 229 9 695 322 889]
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(w[j], x[j]) for j in 1:n],
+            0.0,
+        ),
+        MOI.LessThan(W),
+    )
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(-C[i, j], x[j]))
+            for i in 1:p for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        0 1 1 0 1 0 1 0 1 1
+        0 1 1 0 1 1 1 1 1 0
+        0 0 1 0 1 1 1 0 1 1
+        0 1 1 1 1 0 1 0 1 0
+        1 1 1 0 1 1 1 0 0 0
+        0 1 0 0 0 1 1 1 1 1
+        0 1 1 1 0 1 1 0 1 0
+        0 0 1 1 0 1 1 1 1 0
+        0 0 1 1 1 1 1 0 1 0
+        0 1 1 1 1 1 1 0 0 0
+    ]
+    Y_N = Float64[
+        -2862 -3648 -3049 -2028
+        -3152 -3232 -3596 -3382
+        -2435 -3618 -2282 -2094
+        -2725 -4064 -2652 -1819
+        -3269 -2320 -3059 -2891
+        -2146 -1944 -2947 -3428
+        -2092 -3244 -2643 -2705
+        -1904 -3253 -2530 -2469
+        -2298 -4034 -1885 -1885
+        -2883 -3237 -2535 -2397
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_knapsack_max_p4()
+    p = 4
+    n = 10
+    W = 2653.0
+    C = Float64[
+        566 611 506 180 817 184 585 423 26 317
+        62 84 977 979 874 54 269 93 881 563
+        664 982 962 140 224 215 12 869 332 537
+        557 898 148 63 78 964 246 662 386 272
+    ]
+    w = Float64[979 448 355 955 426 229 9 695 322 889]
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(w[j], x[j]) for j in 1:n],
+            0.0,
+        ),
+        MOI.LessThan(W),
+    )
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(C[i, j], x[j])) for
+            i in 1:p for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        0 1 1 0 1 0 1 0 1 1
+        0 1 1 0 1 1 1 1 1 0
+        0 0 1 0 1 1 1 0 1 1
+        0 1 1 1 1 0 1 0 1 0
+        1 1 1 0 1 1 1 0 0 0
+        0 1 0 0 0 1 1 1 1 1
+        0 1 1 1 0 1 1 0 1 0
+        0 0 1 1 0 1 1 1 1 0
+        0 0 1 1 1 1 1 0 1 0
+        0 1 1 1 1 1 1 0 0 0
+    ]
+    Y_N = Float64[
+        2862 3648 3049 2028
+        3152 3232 3596 3382
+        2435 3618 2282 2094
+        2725 4064 2652 1819
+        3269 2320 3059 2891
+        2146 1944 2947 3428
+        2092 3244 2643 2705
+        1904 3253 2530 2469
+        2298 4034 1885 1885
+        2883 3237 2535 2397
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_assignment_min_p3()
+    if Sys.WORD_SIZE == 32
+        return  # Skip on 32-bit because HiGHS fails
+    end
+    p = 3
+    n = 5
+    C = Float64[
+        6 1 20 2 3
+        2 6 9 10 18
+        1 6 20 5 9
+        6 8 6 9 6
+        7 10 10 6 2
+        17 20 8 8 20
+        10 13 1 10 15
+        4 11 1 13 1
+        19 13 7 18 17
+        15 3 5 1 11
+        10 7 1 19 12
+        2 15 12 10 3
+        11 20 16 12 9
+        10 15 20 11 7
+        1 9 20 7 6
+    ]
+    C = permutedims(reshape(C, (n, p, n)), [2, 1, 3])
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = [MOI.add_variable(model) for i in 1:n, j in 1:n]
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    for i in 1:n
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(1.0, x[i, j]) for j in 1:n],
+                0.0,
+            ),
+            MOI.EqualTo(1.0),
+        )
+    end
+    for j in 1:n
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(1.0, x[i, j]) for i in 1:n],
+                0.0,
+            ),
+            MOI.EqualTo(1.0),
+        )
+    end
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(k, MOI.ScalarAffineTerm(C[k, i, j], x[i, j])) for k in 1:p for i in 1:n for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
+        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
+        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
+        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 0 0 0 1 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0
+    ]
+    Y_N = Float64[
+        28 33 58
+        40 47 37
+        39 43 41
+        45 33 34
+        29 29 59
+        20 52 54
+        28 66 39
+        50 40 32
+        16 61 47
+        35 49 39
+        37 55 36
+        24 39 45
+        18 47 67
+        22 54 47
+        38 33 53
+        34 60 42
+        23 43 44
+        17 43 71
+        22 37 63
+        43 51 31
+        35 38 56
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol =
+        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_assignment_max_p3()
+    if Sys.WORD_SIZE == 32
+        return  # Skip on 32-bit because HiGHS fails
+    end
+    p = 3
+    n = 5
+    C = Float64[
+        6 1 20 2 3
+        2 6 9 10 18
+        1 6 20 5 9
+        6 8 6 9 6
+        7 10 10 6 2
+        17 20 8 8 20
+        10 13 1 10 15
+        4 11 1 13 1
+        19 13 7 18 17
+        15 3 5 1 11
+        10 7 1 19 12
+        2 15 12 10 3
+        11 20 16 12 9
+        10 15 20 11 7
+        1 9 20 7 6
+    ]
+    C = permutedims(reshape(C, (n, p, n)), [2, 1, 3])
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = [MOI.add_variable(model) for i in 1:n, j in 1:n]
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    for i in 1:n
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(1.0, x[i, j]) for j in 1:n],
+                0.0,
+            ),
+            MOI.EqualTo(1.0),
+        )
+    end
+    for j in 1:n
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(1.0, x[i, j]) for i in 1:n],
+                0.0,
+            ),
+            MOI.EqualTo(1.0),
+        )
+    end
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(k, MOI.ScalarAffineTerm(-C[k, i, j], x[i, j])) for k in 1:p for i in 1:n for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    X_E = Float64[
+        0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 1 0 0 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0
+        0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1
+        0 0 0 0 1 1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 1 0
+        0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0 0 0 0 0 1
+        0 1 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 0 0 1 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1
+        1 0 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 0 0 1 0 0 1 0 0
+        0 1 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 1
+        0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 1 0
+        0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 0 0 1
+        0 0 1 0 0 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 1
+        0 1 0 0 0 0 0 0 0 1 1 0 0 0 0 0 0 1 0 0 0 0 0 1 0
+        0 0 0 0 1 0 0 0 1 0 0 1 0 0 0 1 0 0 0 0 0 0 1 0 0
+    ]
+    Y_N = Float64[
+        -28 -33 -58
+        -40 -47 -37
+        -39 -43 -41
+        -45 -33 -34
+        -29 -29 -59
+        -20 -52 -54
+        -28 -66 -39
+        -50 -40 -32
+        -16 -61 -47
+        -35 -49 -39
+        -37 -55 -36
+        -24 -39 -45
+        -18 -47 -67
+        -22 -54 -47
+        -38 -33 -53
+        -34 -60 -42
+        -23 -43 -44
+        -17 -43 -71
+        -22 -37 -63
+        -43 -51 -31
+        -35 -38 -56
+    ]
+    N = MOI.get(model, MOI.ResultCount())
+    x_sol =
+        hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
+    @test isapprox(x_sol, X_E'; atol = 1e-6)
+    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
+    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    return
+end
+
+function test_infeasible()
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    MOI.add_constraint(model, 1.0 * x[1] + 1.0 * x[2], MOI.LessThan(-1.0))
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
+    return
+end
+
+function test_unbounded()
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
+    return
+end
+
+function test_no_bounding_box()
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    @test_logs (:warn,) MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
+    return
+end
+
+function test_time_limit()
+    p = 3
+    n = 10
+    W = 2137.0
+    C = Float64[
+        566 611 506 180 817 184 585 423 26 317
+        62 84 977 979 874 54 269 93 881 563
+        664 982 962 140 224 215 12 869 332 537
+    ]
+    w = Float64[557, 898, 148, 63, 78, 964, 246, 662, 386, 272]
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.TimeLimitSec(), 0.0)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, n)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(w[j], x[j]) for j in 1:n],
+            0.0,
+        ),
+        MOI.LessThan(W),
+    )
+    f = MOI.VectorAffineFunction(
+        [
+            MOI.VectorAffineTerm(i, MOI.ScalarAffineTerm(-C[i, j], x[j]))
+            for i in 1:p for j in 1:n
+        ],
+        fill(0.0, p),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.TIME_LIMIT
+    @test MOI.get(model, MOI.ResultCount()) == 0
+    return
+end
+
+function test_vector_of_variables_objective()
+    model = MOI.instantiate(; with_bridge_type = Float64) do
+        return MOA.Optimizer(HiGHS.Optimizer)
+    end
+    MOI.set(model, MOA.Algorithm(), MOA.TambyVanderpooten())
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.ZeroOne())
+    f = MOI.VectorOfVariables(x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.add_constraint(model, sum(1.0 * xi for xi in x), MOI.GreaterThan(1.0))
+    MOI.optimize!(model)
+    MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    return
+end
+
+end
+
+TestTambyVanderpooten.run_tests()


### PR DESCRIPTION
Link: https://doi.org/10.1287/ijoc.2020.0953

This algorithm keeps a list of upper bounds and the set of 'defining points' associated with each upper bound. After selecting an upper bound to find the next non-dominated point, one of the defining points for that upper bound is used as a starting solution. A warning is raised if the solver does not support `VariablePrimalStart`.