### PR TITLE
Add support for VectorNonlinearFunction objectives

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.1.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 Combinatorics = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,12 @@ version = "1.1.0"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 Combinatorics = "1"
 HiGHS = "1"
 Ipopt = "1"
-MathOptInterface = "1.15"
+MathOptInterface = "1.19"
 julia = "1.6"
 
 [extras]

--- a/src/algorithms/EpsilonConstraint.jl
+++ b/src/algorithms/EpsilonConstraint.jl
@@ -106,7 +106,7 @@ function optimize_multiobjective!(
     end
     ci = MOI.add_constraint(model, f1, SetType(bound))
     status = MOI.OPTIMAL
-    while true
+    for _ in 1:n_points
         if _time_limit_exceeded(model, start_time)
             status = MOI.TIME_LIMIT
             break

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,6 @@
 #  v.2.0. If a copy of the MPL was not distributed with this file, You can
 #  obtain one at http://mozilla.org/MPL/2.0/.
 
-import Pkg
-Pkg.pkg"add MathOptInterface#master"
-
 using Test
 
 @testset "$file" for file in readdir(joinpath(@__DIR__, "algorithms"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,9 @@
 #  v.2.0. If a copy of the MPL was not distributed with this file, You can
 #  obtain one at http://mozilla.org/MPL/2.0/.
 
+import Pkg
+Pkg.pkg"add MathOptInterface#master"
+
 using Test
 
 @testset "$file" for file in readdir(joinpath(@__DIR__, "algorithms"))


### PR DESCRIPTION
<s>Currently blocked by the lack of `Utilities.eval_variables(f::Function, ::ScalarNonlinearFunction)`.</s>

- [x] Requires https://github.com/jump-dev/MathOptInterface.jl/pull/2201