### PR TITLE
Add support for TimeLimitSec to Lexicographic

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -596,6 +596,10 @@ function _compute_point(
     return X, Y
 end
 
+function _is_scalar_status_feasible_point(status::MOI.ResultStatusCode)
+    return status == MOI.FEASIBLE_POINT
+end
+
 function _is_scalar_status_optimal(status::MOI.TerminationStatusCode)
     return status == MOI.OPTIMAL || status == MOI.LOCALLY_SOLVED
 end

--- a/src/algorithms/Lexicographic.jl
+++ b/src/algorithms/Lexicographic.jl
@@ -73,7 +73,8 @@ function optimize_multiobjective!(algorithm::Lexicographic, model::Optimizer)
     solutions = SolutionPoint[]
     status = MOI.OPTIMAL
     for sequence in Combinatorics.permutations(sequence)
-        status, solution = _solve_in_sequence(algorithm, model, sequence, start_time)
+        status, solution =
+            _solve_in_sequence(algorithm, model, sequence, start_time)
         if !isempty(solution)
             push!(solutions, solution[1])
         end


### PR DESCRIPTION
Hi, I have added support for TimeLimitSec to the Lexicographic search algorithm.
- Given a fixed sequence of objectives, it returns the last solution found, even if not proved optimal for all objectives. The last found is very likely the best one found for this fixed sequence of objectives thanks to the additional constraints that are added after each iteration. (By the way, could we not warm-start each iteration with the solution previously found?)
- When solutions for all permutations of the objectives are asked, it simply collects all the solutions found by the above procedure for as many permutations as possible, whether optimal or not, and filters the dominated ones as before.
I hope that makes sense, I just started learning JuMP so it might not be perfect.