### PR TITLE
Over-estimate nadir point in algorithms to fix cycling

### DIFF
--- a/src/algorithms/DominguezRios.jl
+++ b/src/algorithms/DominguezRios.jl
@@ -182,7 +182,7 @@ function optimize_multiobjective!(algorithm::DominguezRios, model::Optimizer)
             return status, nothing
         end
         _, Y = _compute_point(model, variables, f_i)
-        yN[i] = Y
+        yN[i] = Y + 1
     end
     MOI.set(model.inner, MOI.ObjectiveSense(), sense)
     ϵ = 1 / (2 * n * (maximum(yN - yI) - 1))

--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -110,7 +110,7 @@ function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
             return status, nothing
         end
         _, Y = _compute_point(model, variables, f_i)
-        yI[i] = Y
+        yI[i] = Y + 1
         MOI.set(
             model.inner,
             MOI.ObjectiveSense(),

--- a/src/algorithms/TambyVanderpooten.jl
+++ b/src/algorithms/TambyVanderpooten.jl
@@ -113,7 +113,7 @@ function optimize_multiobjective!(
             return status, nothing
         end
         _, Y = _compute_point(model, variables, f_i)
-        yI[i] = Y
+        yI[i] = Y + 1
         MOI.set(model.inner, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         MOI.optimize!(model.inner)
         status = MOI.get(model.inner, MOI.TerminationStatus())

--- a/test/algorithms/DominguezRios.jl
+++ b/test/algorithms/DominguezRios.jl
@@ -79,9 +79,9 @@ function test_knapsack_min_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -138,9 +138,9 @@ function test_knapsack_max_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -204,9 +204,9 @@ function test_knapsack_min_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -270,9 +270,9 @@ function test_knapsack_max_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 

--- a/test/algorithms/DominguezRios.jl
+++ b/test/algorithms/DominguezRios.jl
@@ -79,9 +79,9 @@ function test_knapsack_min_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -138,9 +138,9 @@ function test_knapsack_max_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -204,9 +204,9 @@ function test_knapsack_min_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -270,9 +270,9 @@ function test_knapsack_max_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -380,9 +380,9 @@ function test_assignment_min_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -490,9 +490,9 @@ function test_assignment_max_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 

--- a/test/algorithms/DominguezRios.jl
+++ b/test/algorithms/DominguezRios.jl
@@ -380,9 +380,9 @@ function test_assignment_min_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -490,9 +490,9 @@ function test_assignment_max_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -583,7 +583,7 @@ function test_time_limit()
     return
 end
 
-function __FAIL__test_vector_of_variables_objective()
+function test_vector_of_variables_objective()
     model = MOI.instantiate(; with_bridge_type = Float64) do
         return MOA.Optimizer(HiGHS.Optimizer)
     end

--- a/test/algorithms/KirlikSayin.jl
+++ b/test/algorithms/KirlikSayin.jl
@@ -76,9 +76,9 @@ function test_knapsack_min_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -135,9 +135,9 @@ function test_knapsack_max_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -201,9 +201,9 @@ function test_knapsack_min_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -267,9 +267,9 @@ function test_knapsack_max_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -380,9 +380,9 @@ function test_assignment_min_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 
@@ -493,9 +493,9 @@ function test_assignment_max_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(x_sol, X_E'; atol = 1e-6)
-    y_sol = hcat([MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:N]...)
-    @test isapprox(y_sol, Y_N'; atol = 1e-6)
+    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
+    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
     return
 end
 

--- a/test/algorithms/KirlikSayin.jl
+++ b/test/algorithms/KirlikSayin.jl
@@ -76,9 +76,9 @@ function test_knapsack_min_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -135,9 +135,9 @@ function test_knapsack_max_p3()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -201,9 +201,9 @@ function test_knapsack_min_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -267,9 +267,9 @@ function test_knapsack_max_p4()
     ]
     N = MOI.get(model, MOI.ResultCount())
     x_sol = hcat([MOI.get(model, MOI.VariablePrimal(i), x) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -380,9 +380,9 @@ function test_assignment_min_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 
@@ -493,9 +493,9 @@ function test_assignment_max_p3()
     N = MOI.get(model, MOI.ResultCount())
     x_sol =
         hcat([MOI.get(model, MOI.VariablePrimal(i), vec(x)) for i in 1:N]...)
-    @test isapprox(sort(x_sol; dims=1), sort(X_E'; dims=1); atol = 1e-6)
+    @test isapprox(sort(x_sol; dims = 1), sort(X_E'; dims = 1); atol = 1e-6)
     y_sol = vcat([MOI.get(model, MOI.ObjectiveValue(i))' for i in 1:N]...)
-    @test isapprox(sort(y_sol; dims=1), sort(Y_N; dims=1); atol = 1e-6)
+    @test isapprox(sort(y_sol; dims = 1), sort(Y_N; dims = 1); atol = 1e-6)
     return
 end
 


### PR DESCRIPTION
I think #72 is because, in DominguezRios, we have `ϵ = 1 / (2 * n * (maximum(yN - yI) - 1))`. Because of the objective range, this does not work with models we solve during iterations.

Also, in `KirlikSayin` and `TambyVanderpooten`, we only find one nondominated point. This has to do with management of search space (again because of the nadir point)

We already overestimate the nadir point by reversing `ObjectiveSense`. Maybe, adding +1 to `yN` can solve the problem.

I am working on a PR. This fixes the issue but messes up the order of nondominated points which causes other tests to fail so I will sort the set of nondominated points in `Y_N` before comparing.