### PR TITLE
Fix test return for new HiGHS version

### DIFF
--- a/test/algorithms/Lexicographic.jl
+++ b/test/algorithms/Lexicographic.jl
@@ -148,8 +148,6 @@ function test_unbounded()
         MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         MOI.optimize!(model)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
-        @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
-        @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
     end
     return
 end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -72,8 +72,6 @@ function test_unbounded()
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
-    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
-    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
     return
 end
 


### PR DESCRIPTION
HiGHS v1.7.1 can now return a feasible point, even if the problem is unbounded.