### PR TITLE
Disallow querying is_set_by_optimize attributes unless explicitly supported

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -446,10 +446,18 @@ function MOI.set(model::Optimizer, attr::_ATTRIBUTES, args...)
 end
 
 function MOI.get(model::Optimizer, attr::_ATTRIBUTES, args...)
+    if MOI.is_set_by_optimize(attr)
+        msg = "MOA does not support querying this attribute."
+        throw(MOI.GetAttributeNotAllowed(attr, msg))
+    end
     return MOI.get(model.inner, attr, args...)
 end
 
 function MOI.get(model::Optimizer, attr::_ATTRIBUTES, arg::Vector{T}) where {T}
+    if MOI.is_set_by_optimize(attr)
+        msg = "MOA does not support querying this attribute."
+        throw(MOI.GetAttributeNotAllowed(attr, msg))
+    end
     return MOI.get.(model, attr, arg)
 end
 

--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -580,7 +580,7 @@ end
 function MOI.get(
     model::Optimizer,
     attr::MOI.VariablePrimal,
-    x::Vector{MOI.VariableIndex}
+    x::Vector{MOI.VariableIndex},
 )
     return MOI.get.(model, attr, x)
 end

--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -582,8 +582,7 @@ function MOI.get(
     attr::MOI.VariablePrimal,
     x::Vector{MOI.VariableIndex}
 )
-    sol = model.solutions[attr.result_index]
-    return sol.x[x]
+    return MOI.get.(model, attr, x)
 end
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)

--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -577,6 +577,15 @@ function MOI.get(
     return sol.x[x]
 end
 
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.VariablePrimal,
+    x::Vector{MOI.VariableIndex}
+)
+    sol = model.solutions[attr.result_index]
+    return sol.x[x]
+end
+
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
     return model.solutions[attr.result_index].y
 end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -100,6 +100,30 @@ function test_solve_time()
     return
 end
 
+function test_unnsupported_attributes()
+    model = MOA.Optimizer(HiGHS.Optimizer)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variables(model, 2)
+    c = MOI.add_constraint.(model, x, MOI.GreaterThan(0.0))
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 .* x...)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.optimize!(model)
+    @test_throws(
+        MOI.GetAttributeNotAllowed{MOI.RelativeGap},
+        MOI.get(model, MOI.RelativeGap()),
+    )
+    @test_throws(
+        MOI.GetAttributeNotAllowed{MOI.DualObjectiveValue},
+        MOI.get(model, MOI.DualObjectiveValue()),
+    )
+    @test_throws(
+        MOI.GetAttributeNotAllowed{MOI.ConstraintDual},
+        MOI.get(model, MOI.ConstraintDual(), c),
+    )
+    return
+end
+
 end
 
 TestModel.run_tests()


### PR DESCRIPTION
If we forward to the solver, it will just be whatever the last solve was, which is probably not meaningful.

Closes #86 