### PR TITLE
Add time limits to compute ideal point & dichotomy starting solutions

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -567,8 +567,7 @@ function _compute_ideal_point(model::Optimizer, start_time)
     end
     for (i, f) in enumerate(objectives)
         if _time_limit_exceeded(model, start_time)
-            status = MOI.TIME_LIMIT
-            break
+            return
         end
         MOI.set(model.inner, MOI.ObjectiveFunction{typeof(f)}(), f)
         MOI.optimize!(model.inner)

--- a/src/algorithms/Dichotomy.jl
+++ b/src/algorithms/Dichotomy.jl
@@ -81,11 +81,17 @@ function optimize_multiobjective!(algorithm::Dichotomy, model::Optimizer)
         error("Only scalar or bi-objective problems supported.")
     end
     if MOI.output_dimension(model.f) == 1
+        if _time_limit_exceeded(model, start_time)
+            return MOI.TIME_LIMIT, nothing
+        end
         status, solution = _solve_weighted_sum(model, algorithm, [1.0])
         return status, [solution]
     end
     solutions = Dict{Float64,SolutionPoint}()
     for w in (0.0, 1.0)
+        if _time_limit_exceeded(model, start_time)
+            return MOI.TIME_LIMIT, nothing
+        end
         status, solution = _solve_weighted_sum(model, algorithm, w)
         if !_is_scalar_status_optimal(status)
             return status, nothing

--- a/test/algorithms/Dichotomy.jl
+++ b/test/algorithms/Dichotomy.jl
@@ -261,7 +261,7 @@ function test_time_limit()
     )
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.TIME_LIMIT
-    @test MOI.get(model, MOI.ResultCount()) > 0
+    @test MOI.get(model, MOI.ResultCount()) == 0
     return
 end
 


### PR DESCRIPTION
Hi, 

This PR adds time limits to solving for ideal points, and the first solves of the dichotomy algorithm.

I realise that timing-out when solving for ideal points indicates that the time limit is probably way to small to get anything meaningful from the multi-objective formulation, but this was an edge case I faced, leading to some behaviour I was not expecting.

Also, this brings this package more in line with other MO solvers.  For instance if I just used Gurobi to solve the multi-objective function, then for sure I would expect it to satisfy my time limit.  But currently with this package the solver could go far beyond my time limit. For example, the start time **before** computation of ideal points is not passed down to any of the algorithms, so if it takes a long time to solve for ideal points, and the lower algorithm times out, then the overall solve time could be significantly more than the users time limit. But I haven't touched this because I users can now turn off ideal point calculation.

Hopefully that makes sense.

Finally, the logic before the 0 time limit unit-test for the dichotomy algorithm doesn't make sense to me.  If the user provided a time limit of 0, then I would expect there to be no solutions returned?

Thanks for the package :)