### PR TITLE
Fixed ideal point in KS and nadir point in TV

### DIFF
--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -111,7 +111,7 @@ function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
             return status, nothing
         end
         _, Y = _compute_point(model, variables, f_i)
-        yI[i] = Y + 1
+        yI[i] = Y
         model.ideal_point[i] = Y
         MOI.set(
             model.inner,
@@ -125,7 +125,7 @@ function optimize_multiobjective!(algorithm::KirlikSayin, model::Optimizer)
             return status, nothing
         end
         _, Y = _compute_point(model, variables, f_i)
-        yN[i] = Y
+        yN[i] = Y + 1
     end
     # Reset the sense after modifying it.
     MOI.set(model.inner, MOI.ObjectiveSense(), sense)


### PR DESCRIPTION
Maybe typemax(Float64) is a problem since to select the next search zone to look for nondominated points the algorithm computes hypervolumes which may lead to very large numbers.

I messed up the ideal point computation some time ago when we were solving an edge case for DominuezRios and the vector of variables objective functions. I apologize for this.