### PR TITLE
Slightly improve a tolerance issue in KirlikSayin

### DIFF
--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -170,7 +170,7 @@ function minimize_multiobjective!(
         zₖ_constraint = MOI.Utilities.normalize_and_add_constraint(
             inner,
             scalars[k],
-            MOI.LessThan(zₖ),
+            MOI.LessThan(zₖ + 1e-5),
         )
         optimize_inner!(model)
         if !_is_scalar_status_optimal(model)

--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -170,7 +170,7 @@ function minimize_multiobjective!(
         zₖ_constraint = MOI.Utilities.normalize_and_add_constraint(
             inner,
             scalars[k],
-            MOI.LessThan(zₖ + 1e-5),
+            MOI.LessThan(zₖ),
         )
         optimize_inner!(model)
         if !_is_scalar_status_optimal(model)

--- a/src/algorithms/KirlikSayin.jl
+++ b/src/algorithms/KirlikSayin.jl
@@ -170,7 +170,7 @@ function minimize_multiobjective!(
         zₖ_constraint = MOI.Utilities.normalize_and_add_constraint(
             inner,
             scalars[k],
-            MOI.EqualTo(zₖ),
+            MOI.LessThan(zₖ),
         )
         optimize_inner!(model)
         if !_is_scalar_status_optimal(model)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -258,12 +258,12 @@ function test_printing()
         return
     end
     contents = read(joinpath(dir, "log.txt"), String)
-    for line in [
+    for line in Any[
         "Algorithm: KirlikSayin",
         "1    0.00000e+00  0.00000e+00",
         "----------------------------------------------",
         "termination_status: OPTIMAL",
-        "result_count: 10",
+        r"result_count: [0-9]+",
         "Time spent in subproblems: ",
     ]
         @test occursin(line, contents)


### PR DESCRIPTION
From a previous solve, z_k may be a value like z+eps where z in Z and eps is the feasibility tolerance. However, if scalars[k] is integer valued, then presolve may (somewhat reasonably) deduce that this problem is infeasible. Instead of rounding z_k, changing EqualTo to LessThan seemed to work on the instances I have. I don't know why. There is also a weird situation in which Gurobi declared a problem unbounded. I can't reproduce without running the entire thing, but I think it is a mix of presolve proving that there is no finite solution (because its infeasible) and yet there being a "feasible" MIP solution in memory from the previous solve. It comes down to the weird mix of tolerances in MIP starts, presolve, simplex, and this equality constraint. This is most probably a bug in Gurobi, in that it should either report optimal or infeasible. But not unbounded. I've seem something similar in SDDP.jl.

```julia
using Revise
using JuMP, Gurobi
import MultiObjectiveAlgorithms as MOA

function build_model(filename)
    data = readlines(filename)
    P = parse(Int, data[1])
    N = parse(Int, data[2])
    C = [
        reduce(vcat, (parse.(Int, split(data[2+p*N+n]))' for n in 1:N))
        for p in 0:(P-1)
    ]
    model = Model()
    @variable(model, x[1:N, 1:N], Bin)
    @constraint(model, [i in 1:N], sum(x[i, :]) == 1)
    @constraint(model, [j in 1:N], sum(x[:, j]) == 1)
    @objective(model, Min, [sum(C[p] .* x) for p in 1:P])
    return model
end

function main()
    filename = "AP_p-3_n-15_ins-1.txt"
    model = build_model(filename)
    set_optimizer(model, () -> MOA.Optimizer(Gurobi.Optimizer))
    set_attribute(model, MOA.Algorithm(), MOA.KirlikSayin())
    optimize!(model)
    return solution_summary(model)
end
```
[AP_p-3_n-15_ins-1.txt](https://github.com/user-attachments/files/27380828/AP_p-3_n-15_ins-1.txt)
