### PR TITLE
Disable 32-bit linux CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
           - version: '1.10'  # 1.10 LTS (64-bit Linux)
             os: ubuntu-latest
             arch: x64
-          # Consider disabling
-          - version: '1.10'  # 1.10 LTS (32-bit Linux)
-            os: ubuntu-latest
-            arch: x86
+          # - version: '1.10'  # 1.10 LTS (32-bit Linux)
+          #   os: ubuntu-latest
+          #   arch: x86
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - version: '1.10'  # 1.10 LTS (64-bit Linux)
             os: ubuntu-latest
             arch: x64
+          # Consider disabling
           - version: '1.10'  # 1.10 LTS (32-bit Linux)
             os: ubuntu-latest
             arch: x86


### PR DESCRIPTION
It's stalling in https://github.com/jump-dev/MultiObjectiveAlgorithms.jl/pull/198. Not sure if it is on `master` too.