### PR TITLE
[GeneralDichotomy] handle no solution case

### DIFF
--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -24,9 +24,8 @@ function MOA.minimize_multiobjective!(
     # Storage we need for the algorithm.
     weights, solutions = Weight[], MOA.SolutionPoint[]
     n_obj = MOI.output_dimension(model.f)
-    # First, minimize the first objective to obtain a primal feasible point.
-    w = zeros(Float64, n_obj)
-    w[1] = 1.0
+    # First, minimize the combined objectives to obtain a primal feasible point.
+    w = ones(Float64, n_obj)
     status, solution = MOA._solve_weighted_sum(model, alg, w)
     if solution === nothing
         return status, nothing
@@ -40,7 +39,7 @@ function MOA.minimize_multiobjective!(
         w[i] = 1.0
         z = w' * solution.y
         adj_bnd = Int[-j for j in 1:n_obj if j != i]
-        push!(weights, Weight(w, z, adj_bnd, [1], i == 1, false))
+        push!(weights, Weight(w, z, adj_bnd, [1], false, false))
     end
     # Prevent solution duplicates: existing_sol maps an rounded objective vector
     # to its index in `solutions::Vector{MOA.SolutionPoint}`.
@@ -59,8 +58,7 @@ function MOA.minimize_multiobjective!(
             end
             status, sol = MOA._solve_weighted_sum(model, alg, weight.w)
             if sol === nothing
-                # TODO(odow): what to do when this solve fails?
-                return status, solutions
+                return MOI.NUMERICAL_ERROR, solutions
             end
             weight.tested = true
             if !haskey(existing_sol, _round(sol.y; atol))

--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -24,13 +24,25 @@ function MOA.minimize_multiobjective!(
     # Storage we need for the algorithm.
     weights, solutions = Weight[], MOA.SolutionPoint[]
     n_obj = MOI.output_dimension(model.f)
-    # First, minimize the combined objectives to obtain a primal feasible point.
-    w = ones(Float64, n_obj)
-    status, solution = MOA._solve_weighted_sum(model, alg, w)
-    if solution === nothing
+    # First, search for an initial primal feasible point.
+    init_sol_idx = 0
+    status, solution = nothing, nothing
+    for i in 1:n_obj
+        w = zeros(Float64, n_obj)
+        w[i] = 1.0
+        status, solution = MOA._solve_weighted_sum(model, alg, w)
+        if solution !== nothing
+            if !MOA._is_scalar_status_optimal(model)
+                _log_subproblem_solve(model, "subproblem not optimal")
+            end
+            init_sol_idx = i
+            push!(solutions, solution)
+            break
+        end
+    end
+    if length(solutions) == 0
         return status, nothing
     end
-    push!(solutions, solution)
     # Initialize the weights. There is one weight vector for each objective, and
     # the weight is set to 1.0 for each objective. We use the current solution
     # obtained by minimizing the 1st objective as the reference.
@@ -39,7 +51,9 @@ function MOA.minimize_multiobjective!(
         w[i] = 1.0
         z = w' * solution.y
         adj_bnd = Int[-j for j in 1:n_obj if j != i]
-        push!(weights, Weight(w, z, adj_bnd, [1], false, false))
+        tested = i <= init_sol_idx ? true : false
+        removed = i < init_sol_idx ? true : false
+        push!(weights, Weight(w, z, adj_bnd, [1], tested, removed))
     end
     # Prevent solution duplicates: existing_sol maps an rounded objective vector
     # to its index in `solutions::Vector{MOA.SolutionPoint}`.
@@ -57,10 +71,15 @@ function MOA.minimize_multiobjective!(
                 continue
             end
             status, sol = MOA._solve_weighted_sum(model, alg, weight.w)
-            if sol === nothing
-                return MOI.NUMERICAL_ERROR, solutions
-            end
             weight.tested = true
+            # the weight is skipped if there is no solution
+            # the procedure can continue in case of sub-optimality
+            if sol === nothing
+                continue
+            end
+            if !MOA._is_scalar_status_optimal(model)
+                _log_subproblem_solve(model, "subproblem not optimal")
+            end
             if !haskey(existing_sol, _round(sol.y; atol))
                 push!(solutions, sol)
                 # Prepare new weight index set for the new solution's adjacency.

--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -51,7 +51,7 @@ function MOA.minimize_multiobjective!(
         w[i] = 1.0
         z = w' * solution.y
         adj_bnd = Int[-j for j in 1:n_obj if j != i]
-        tested = i <= init_sol_idx ? true : false
+        tested = i <= init_sol_idx
         removed = i < init_sol_idx
         push!(weights, Weight(w, z, adj_bnd, [1], tested, removed))
     end

--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -52,7 +52,7 @@ function MOA.minimize_multiobjective!(
         z = w' * solution.y
         adj_bnd = Int[-j for j in 1:n_obj if j != i]
         tested = i <= init_sol_idx ? true : false
-        removed = i < init_sol_idx ? true : false
+        removed = i < init_sol_idx
         push!(weights, Weight(w, z, adj_bnd, [1], tested, removed))
     end
     # Prevent solution duplicates: existing_sol maps an rounded objective vector

--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -32,9 +32,6 @@ function MOA.minimize_multiobjective!(
         w[i] = 1.0
         status, solution = MOA._solve_weighted_sum(model, alg, w)
         if solution !== nothing
-            if !MOA._is_scalar_status_optimal(model)
-                _log_subproblem_solve(model, "subproblem not optimal")
-            end
             init_sol_idx = i
             push!(solutions, solution)
             break
@@ -72,13 +69,10 @@ function MOA.minimize_multiobjective!(
             end
             status, sol = MOA._solve_weighted_sum(model, alg, weight.w)
             weight.tested = true
-            # the weight is skipped if there is no solution
-            # the procedure can continue in case of sub-optimality
+            # The weight is skipped if there is no solution. The algortihm can
+            # continue in case of sub-optimality.
             if sol === nothing
                 continue
-            end
-            if !MOA._is_scalar_status_optimal(model)
-                _log_subproblem_solve(model, "subproblem not optimal")
             end
             if !haskey(existing_sol, _round(sol.y; atol))
                 push!(solutions, sol)

--- a/src/algorithms/GeneralDichotomy.jl
+++ b/src/algorithms/GeneralDichotomy.jl
@@ -61,6 +61,7 @@ function _solve_weighted_sum(
     optimize_inner!(model)
     status = MOI.get(model.inner, MOI.TerminationStatus())
     if !_is_scalar_status_optimal(status)
+        _log_subproblem_solve(model, "subproblem not optimal")
         return status, nothing
     end
     variables = MOI.get(model.inner, MOI.ListOfVariableIndices())


### PR DESCRIPTION
Closes #203

In reply to https://github.com/jump-dev/MultiObjectiveAlgorithms.jl/issues/203:

I replaced the initial scalarization by w=(1, .., 1). The missing solution case can be detected at the beginning by solving a simple sum of the objectives:

- if one of the objective is unbounded, any sum with non zero coefficients should be also unbounded
- if the problem is infeasible, any linear scalarization should be infeasible as well

Then, if any sub-problem is infeasible, this must be due to numerical issues, hence returning MOI.NUMERICAL_ERROR in the main loop.

(PS sorry for the duplicate PR)