### PR TITLE
fix issue on GeneralDichotomy initial weights

### DIFF
--- a/ext/Polyhedra/GeneralDichotomy.jl
+++ b/ext/Polyhedra/GeneralDichotomy.jl
@@ -81,15 +81,15 @@ function MOA.minimize_multiobjective!(
         for (i, weight) in enumerate(weights)
             sol_z = weight.w' * new_sol.y
             if sol_z < weight.z - atol
-                # The new solution is strictly better than the previous.
                 if length(weight.adj_bnd) < n_obj
                     weight.removed = true
                     n_removed += 1
-                else
+                end
+                union!(polytope_sol, weight.adj_sol)
+                if !weight.removed
                     weight.adj_sol = Int[new_sol_ind]
                     weight.z = sol_z
                 end
-                union!(polytope_sol, weight.adj_sol)
             elseif sol_z <= weight.z + atol
                 # The new solution is equal in value to the previous.
                 push!(weight.adj_sol, new_sol_ind)
@@ -115,20 +115,7 @@ function MOA.minimize_multiobjective!(
         for idx in eachindex(Polyhedra.points(poly))
             w = get(poly, idx)
             z = w' * new_sol.y
-            if (i = get(equal_weights, _round(w; atol), nothing)) !== nothing
-                # Update an existing extreme weight.
-                weights[i].z = z
-                weights[i].tested = true
-                weights[i].adj_sol = Int[new_sol_ind]
-                if length(weights[i].adj_bnd) < n_obj - 1
-                    if !weights[i].removed
-                        weights[i].removed = true
-                        n_removed += 1
-                    end
-                else
-                    weights[i].removed = false
-                end
-            else
+            if (i = get(equal_weights, _round(w; atol), nothing)) === nothing
                 # Insert a new extreme weight.
                 adj_bnd, adj_sol = Int[], Int[]
                 for elt in Polyhedra.incidenthalfspaceindices(poly, idx)

--- a/test/algorithms/test_GeneralDichotomy.jl
+++ b/test/algorithms/test_GeneralDichotomy.jl
@@ -128,7 +128,9 @@ function test_vlp()
     MOI.set(model, MOA.Algorithm(), MOA.GeneralDichotomy())
     MOI.optimize!(model)
     N = MOI.get(model, MOI.ResultCount())
-    y_sol = round.(Int, 10 .* MOI.get.(model, MOI.ObjectiveValue.(1:N)))
+    y_sol = map(1:N) do i
+        return round.(Int, 10 .* MOI.get(model, MOI.ObjectiveValue(i)))
+    end
     Y_N = [[15, 15, 0], [5, 10, 5], [5, 5, 10], [10, 5, 5]]
     for i in length(Y_N)
         @test Y_N[i] ∈ y_sol

--- a/test/algorithms/test_GeneralDichotomy.jl
+++ b/test/algorithms/test_GeneralDichotomy.jl
@@ -127,6 +127,12 @@ function test_vlp()
     MOI.set(model, MOI.Silent(), true)
     MOI.set(model, MOA.Algorithm(), MOA.GeneralDichotomy())
     MOI.optimize!(model)
+    N = MOI.get(model, MOI.ResultCount())
+    y_sol = [round.(Int, y) for y in (MOI.get.(model, MOI.ObjectiveValue.(1:N)) .* 10)]
+    Y_N = [[15, 15, 0], [5, 10, 5], [5, 5, 10], [10, 5, 5]]
+    for i in length(Y_N)
+        @test Y_N[i] ∈ y_sol
+    end
     return
 end
 

--- a/test/algorithms/test_GeneralDichotomy.jl
+++ b/test/algorithms/test_GeneralDichotomy.jl
@@ -128,7 +128,7 @@ function test_vlp()
     MOI.set(model, MOA.Algorithm(), MOA.GeneralDichotomy())
     MOI.optimize!(model)
     N = MOI.get(model, MOI.ResultCount())
-    y_sol = [round.(Int, y) for y in (MOI.get.(model, MOI.ObjectiveValue.(1:N)) .* 10)]
+    y_sol = round.(Int, 10 .* MOI.get.(model, MOI.ObjectiveValue.(1:N)))
     Y_N = [[15, 15, 0], [5, 10, 5], [5, 5, 10], [10, 5, 5]]
     for i in length(Y_N)
         @test Y_N[i] ∈ y_sol


### PR DESCRIPTION
This commit solves an issue on the weight update procedure in GeneralDichotomy.
Initial weights could be previously  wrongly updated, which makes the bensolve vlp instance test fails (<http://www.bensolve.org/>).

The method should be able to find at least the four upper image points: 

![Bensolve test instance](https://users.fmi.uni-jena.de/~sa67leb/bensolve/pics/screenshot_ex05.png)
