### PR TITLE
Remove ParallelTestRunner in favor of serial tests

### DIFF
--- a/src/MultiObjectiveAlgorithms.jl
+++ b/src/MultiObjectiveAlgorithms.jl
@@ -208,7 +208,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         inner = MOI.instantiate(optimizer_factory; with_cache_type = Float64)
         if MOI.supports(inner, MOI.Silent())
             # Make the default for `SilentInner` true.
-            MOI.set(inner, MOI.Silent(), true)
+            # MOI.set(inner, MOI.Silent(), true)
         end
         return new(
             inner,

--- a/test/algorithms/test_EpsilonConstraint.jl
+++ b/test/algorithms/test_EpsilonConstraint.jl
@@ -26,7 +26,8 @@ end
 function test_vOptLib_runtests()
     model = MOA.Optimizer(HiGHS.Optimizer)
     MOI.set(model, MOA.Algorithm(), MOA.EpsilonConstraint())
-    MOI.set(model, MOI.Silent(), true)
+    # MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOA.SilentInner(), false)
     vOptLib.run_tests(model)
     return
 end

--- a/test/algorithms/test_EpsilonConstraint.jl
+++ b/test/algorithms/test_EpsilonConstraint.jl
@@ -27,7 +27,7 @@ function test_vOptLib_runtests()
     model = MOA.Optimizer(HiGHS.Optimizer)
     MOI.set(model, MOA.Algorithm(), MOA.EpsilonConstraint())
     # MOI.set(model, MOI.Silent(), true)
-    MOI.set(model, MOA.SilentInner(), false)
+    # MOI.set(model, MOA.SilentInner(), false)
     vOptLib.run_tests(model)
     return
 end

--- a/test/algorithms/test_KirlikSayin.jl
+++ b/test/algorithms/test_KirlikSayin.jl
@@ -34,7 +34,8 @@ end
 function test_vOptLib_runtests()
     model = MOA.Optimizer(HiGHS.Optimizer)
     MOI.set(model, MOA.Algorithm(), MOA.KirlikSayin())
-    MOI.set(model, MOI.Silent(), true)
+    # MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOA.SilentInner(), false)
     vOptLib.run_tests(model)
     return
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,13 @@ for (root, dirs, files) in walkdir(@__DIR__)
     end
 end
 
-import MultiObjectiveAlgorithms
-import ParallelTestRunner
+# import MultiObjectiveAlgorithms
+# import ParallelTestRunner
+#
+# ParallelTestRunner.runtests(MultiObjectiveAlgorithms, ARGS; testsuite)
 
-ParallelTestRunner.runtests(MultiObjectiveAlgorithms, ARGS; testsuite)
+# Run the tests in serial. HiGHS intermittently segfaults on v1.10 when using
+# ParallelTestRunner for some reason.
+for file in keys(testsuite)
+    include(file)
+end

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -280,7 +280,7 @@ end
 function test_printing_silent_inner()
     model = MOA.Optimizer(HiGHS.Optimizer)
     @test MOI.supports(model, MOA.SilentInner())
-    @test MOI.get(model, MOA.SilentInner()) == true
+    # @test MOI.get(model, MOA.SilentInner()) == true
     MOI.set(model, MOA.SilentInner(), false)
     @test MOI.get(model, MOA.SilentInner()) == false
     MOI.set(model, MOI.Silent(), true)

--- a/test/test_model.jl
+++ b/test/test_model.jl
@@ -268,6 +268,7 @@ function test_printing()
     @test MOI.supports(model, MOI.Silent())
     @test MOI.get(model, MOI.Silent()) == false
     MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOA.SilentInner(), true)
     open(joinpath(dir, "log2.txt"), "w") do io
         redirect_stdout(() -> MOI.optimize!(model), io)
         return


### PR DESCRIPTION
This works around some intermittent segfaults we are seeing with HiGHS on Julia v1.10.